### PR TITLE
Revert "REVERT THIS BEFORE UPDATE ion: Rename heap_mask when used in use...

### DIFF
--- a/include/linux/ion.h
+++ b/include/linux/ion.h
@@ -348,12 +348,7 @@ static inline int ion_handle_get_flags(struct ion_client *client,
 struct ion_allocation_data {
 	size_t len;
 	size_t align;
-#ifdef  __KERNEL__
 	unsigned int heap_mask;
-#else
-        /* Userspace wants this renamed... */
-	unsigned int heap_id_mask;
-#endif
 	unsigned int flags;
 	struct ion_handle *handle;
 };


### PR DESCRIPTION
...rspace"

This reverts commit 6171df8b5721792d3052762246bd48ac3314a2c0.

Change-Id: I985914b375cddb4a6e3b8c09f03b434d27aa1ac0